### PR TITLE
Include the possibility to add HTML on the cells.

### DIFF
--- a/src/CaoHtmlTable/Model/Table.php
+++ b/src/CaoHtmlTable/Model/Table.php
@@ -27,11 +27,17 @@ class Table
     protected $attributes;
 
     /**
+     * @var string
+     */
+    protected $escapePlugin;
+
+    /**
      * @param array $rows - Array of rows for the table
      */
     public function __construct(array $rows = array())
     {
         $this->rows = $rows;
+        $this->escapePlugin = 'escapehtml';
     }
 
     /**
@@ -149,5 +155,24 @@ class Table
     public function hasAttributes()
     {
         return isset($this->attributes);
+    }
+
+    /**
+     * @param string $escapePlugin
+     * @return Table
+     */
+    public function setEscape($escapePlugin)
+    {
+        $this->escapePlugin = $escapePlugin;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEscape()
+    {
+        return $this->escapePlugin;
     }
 }

--- a/src/CaoHtmlTable/View/Helper/CaoHtmlTable.php
+++ b/src/CaoHtmlTable/View/Helper/CaoHtmlTable.php
@@ -8,6 +8,7 @@ use Zend\Stdlib\ArrayUtils;
 
 class CaoHtmlTable extends AbstractHtmlElement
 {
+
     /**
      * Generates a 'Table' element.
      *
@@ -30,7 +31,7 @@ class CaoHtmlTable extends AbstractHtmlElement
         }
 
         $html = '<table' . $attribs . '>' . self::EOL;
-        $escape = $this->getView()->plugin('escapehtml');
+        $escape = null != $table->getEscape() ? $this->getView()->plugin($table->getEscape()) : function ($str) { return $str; };
 
         if ($table->hasCaption()) {
             $html .= '<caption>' . $escape($table->getCaption()) . '</caption>' . self::EOL;


### PR DESCRIPTION
For backward compatibility, by default, it still uses escapehtml. A new
property was added to the Table model, to keep which plugin must be used
to escape the content of the table.

When it is set to null `$table->setEscape(null)`, it doesn't apply any
change/parsing, thus allowing the insertion of HTML into  the cells.